### PR TITLE
Fix scrollPosition and added different alignments

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,31 @@
-scroll-to-element
-=====
+# scroll-to-element
 
-Smooth scrolls to element of the specified selector or element reference with optional offset, easing, and duration via [scroll-to](https://www.npmjs.com/package/scroll-to)
+Smooth scrolls to element of the specified selector or element reference with optional offset, scroll-positon, easing, and duration via [scroll-to](https://www.npmjs.com/package/scroll-to)
 
 [![NPM](https://nodei.co/npm/scroll-to-element.png)](https://nodei.co/npm/scroll-to-element/)
 
-EXAMPLE
-====
+## `scrollToElement(selector, <options>)`
+##### Valid options:
 
-`scrollToElement(selector, <options>)`
----
+###### offset : *number*
+
+> Add an additional offset to the final position. if
+> \> 0 then page is moved to the bottom otherwise the page is moved to the top.
+
+###### align : *string*
+
+> Alignment of the element in the resulting viewport. Can be
+> one of `'top'`, `'middle'` or `'bottom'`. Defaulting to `'top'`.
+
+###### ease : *string*
+
+> Easing function defaulting to "out-circ" (view [ease](https://github.com/component/ease) for more)
+
+###### duration : *number*
+
+> Animation duration defaulting to `1000`
+
+## EXAMPLE
 
 ```js
 var scrollToElement = require('scroll-to-element');
@@ -32,7 +48,6 @@ scrollToElement(elem, {
 });
 ```
 
-LICENSE
-=======
+## LICENSE
 
 MIT

--- a/index.js
+++ b/index.js
@@ -1,7 +1,25 @@
 var scroll = require('scroll-to');
 
+function calculateScrollOffset(elem, additionalOffset, alignment) {
+  var elemRect = elem.getBoundingClientRect();
+  var clientHeight = document.documentElement.clientHeight;
+
+  additionalOffset = additionalOffset || 0;
+
+  var scrollPosition;
+  if (alignment === 'bottom') {
+    scrollPosition = elemRect.bottom - clientHeight;
+  } else if (alignment === 'middle') {
+    scrollPosition = elemRect.bottom - clientHeight / 2 - elemRect.height / 2;
+  } else { // top and default
+    scrollPosition = elemRect.top;
+  }
+
+  return scrollPosition + additionalOffset + window.pageYOffset;
+}
+
 module.exports = function (elem, options) {
   options = options || {};
   if (typeof elem === 'string') elem = document.querySelector(elem);
-  if (elem) scroll(0, elem.offsetTop + (options.offset || 0), options);
+  if (elem) scroll(0, calculateScrollOffset(elem, options.offset, options.align), options);
 };


### PR DESCRIPTION
elem.offsetTop is not working if the element to be scrolled to is inside an relative placed container. In that case it makes more sense to use getBoundingClientRect() to get the real offset relative to the viewport.
Added 2 more ways to align the element in the viewport : bottom and middle

And also added all the options to the readme
